### PR TITLE
Add missing import in OsmSite.php

### DIFF
--- a/includes/OsmSite.php
+++ b/includes/OsmSite.php
@@ -26,6 +26,7 @@
 
 namespace OsmWikibase;
 
+use MediaWiki\Site\MediaWikiPageNameNormalizer;
 use Site;
 use Title;
 


### PR DESCRIPTION
This was missed in #2. Not tested (I don’t have Wikibase set up), but this is how it looks like in MediaWiki core.

Fixes #1 (hopefully).